### PR TITLE
Add mirror status workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,22 +43,3 @@ jobs:
       - name: Test
         id: npm-ci-test
         run: npm run ci-test
-
-  # test-action:
-  #   name: GitHub Actions Test
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Checkout
-  #       id: checkout
-  #       uses: actions/checkout@v4
-
-  #     - name: Test Local Action
-  #       id: test-action
-  #       uses: ./
-  #       with:
-  #         milliseconds: 2000
-
-  #     - name: Print Output
-  #       id: output
-  #       run: echo "${{ steps.test-action.outputs.time }}"

--- a/.github/workflows/mirror-status.yml
+++ b/.github/workflows/mirror-status.yml
@@ -1,0 +1,22 @@
+on:
+  status:
+
+run-name:
+  Mirror status ${{ github.event.context }} for ${{ github.ref }}
+  (${{github.event_name }})
+
+jobs:
+  commit-status:
+    if:
+      github.event.context == 'continuous-integration/drone/push' &&
+      startsWith(github.event.branches[0].name, 'gh-readonly-queue/main/')
+
+    permissions:
+      statuses: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mirror commit status
+        uses: ./
+        with:
+          to-status: continuous-integration/drone/pr


### PR DESCRIPTION
This is effectively our testcase where we call ourselves to see if we can successfully mirror the Drone status.

We'll turn merge queues on in this repo, and then PRs won't be able to go in if this action is broken.