### PR TITLE
ci: Run required workflows when added to the merge queue

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,6 +9,9 @@
 # expected from the build.
 name: Check Transpiled JavaScript
 
+run-name:
+  Check Transpiled JavaScript for ${{ github.ref }} (${{ github.event_name }})
+
 on:
   pull_request:
     branches:
@@ -16,6 +19,10 @@ on:
   push:
     branches:
       - main
+
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continuous Integration
 
+run-name:
+  Continuous Integration for ${{ github.ref }} (${{ github.event_name }})
+
 on:
   pull_request:
     branches:
@@ -7,6 +10,10 @@ on:
   push:
     branches:
       - main
+
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   contents: read


### PR DESCRIPTION
This trigger is needed, otherwise workflows aren't started when PRs are added to the merge queue.